### PR TITLE
chore: no need to set tx isolation level

### DIFF
--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -127,7 +127,7 @@ func (this *ConnectionConfig) GetDBUri(databaseName string) string {
 		"charset=utf8mb4,utf8,latin1",
 		"interpolateParams=true",
 		fmt.Sprintf("tls=%s", tlsOption),
-		fmt.Sprintf("transaction_isolation=%q", this.TransactionIsolation),
+		// fmt.Sprintf("transaction_isolation=%q", this.TransactionIsolation),
 		fmt.Sprintf("timeout=%fs", this.Timeout),
 		fmt.Sprintf("readTimeout=%fs", this.Timeout),
 		fmt.Sprintf("writeTimeout=%fs", this.Timeout),


### PR DESCRIPTION
transaction_isolation was introduced in MySQL version 5.7.20, while tx_isolation should be used for earlier versions. Setting transaction_isolation fails on earlier MySQL versions.
gh-ost merely sets transaction_level to REPEATABLE_READ which is the default. So we can just remove this line and everything works.