### PR TITLE
Support custom MySQL dial network

### DIFF
--- a/go/binlog/gomysql_reader.go
+++ b/go/binlog/gomysql_reader.go
@@ -55,6 +55,7 @@ func NewGoMySQLReader(migrationContext *base.MigrationContext) *GoMySQLReader {
 			UseDecimal:              true,
 			TimestampStringLocation: time.UTC,
 			MaxReconnectAttempts:    migrationContext.BinlogSyncerMaxReconnectAttempts,
+			Dialer:                  connectionConfig.Dialer,
 		}),
 	}
 }

--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -31,6 +31,8 @@ type ConnectionConfig struct {
 	Timeout              float64
 	TransactionIsolation string
 	Charset              string
+	// Network is the go-sql-driver network name. When empty, tcp is used.
+	Network string
 
 	// use migrationContext.Uuid if useSSL
 	TLSKey string
@@ -54,6 +56,7 @@ func (this *ConnectionConfig) DuplicateCredentials(key InstanceKey) *ConnectionC
 		Timeout:              this.Timeout,
 		TransactionIsolation: this.TransactionIsolation,
 		Charset:              this.Charset,
+		Network:              this.Network,
 		TLSKey:               this.TLSKey,
 	}
 
@@ -168,7 +171,11 @@ func (this *ConnectionConfig) GetDBUri(databaseName string) string {
 		fmt.Sprintf("writeTimeout=%fs", this.Timeout),
 	}
 
-	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", this.User, this.Password, hostname, this.Key.Port, databaseName, strings.Join(connectionParams, "&"))
+	network := this.Network
+	if network == "" {
+		network = "tcp"
+	}
+	return fmt.Sprintf("%s:%s@%s(%s:%d)/%s?%s", this.User, this.Password, network, hostname, this.Key.Port, databaseName, strings.Join(connectionParams, "&"))
 }
 
 func GetDBTLSConfigKey(tlsKey string, tlsServerName string) string {

--- a/go/mysql/connection.go
+++ b/go/mysql/connection.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strings"
 
+	gomysqlclient "github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-sql-driver/mysql"
 )
 
@@ -33,6 +34,8 @@ type ConnectionConfig struct {
 	Charset              string
 	// Network is the go-sql-driver network name. When empty, tcp is used.
 	Network string
+	// Dialer is used by go-mysql binlog connections. When nil, go-mysql uses net.Dialer.
+	Dialer gomysqlclient.Dialer
 
 	// use migrationContext.Uuid if useSSL
 	TLSKey string
@@ -57,6 +60,7 @@ func (this *ConnectionConfig) DuplicateCredentials(key InstanceKey) *ConnectionC
 		TransactionIsolation: this.TransactionIsolation,
 		Charset:              this.Charset,
 		Network:              this.Network,
+		Dialer:               this.Dialer,
 		TLSKey:               this.TLSKey,
 	}
 

--- a/go/mysql/connection_test.go
+++ b/go/mysql/connection_test.go
@@ -6,9 +6,13 @@
 package mysql
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
+	"net"
 	"testing"
 
+	gomysqlclient "github.com/go-mysql-org/go-mysql/client"
 	"github.com/openark/golib/log"
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +38,7 @@ func TestNewConnectionConfig(t *testing.T) {
 }
 
 func TestDuplicateCredentials(t *testing.T) {
+	dialerErr := errors.New("dialer called")
 	c := NewConnectionConfig()
 	c.Key = InstanceKey{Hostname: "myhost", Port: 3306}
 	c.User = "gromit"
@@ -45,6 +50,9 @@ func TestDuplicateCredentials(t *testing.T) {
 	c.TransactionIsolation = transactionIsolation
 	c.Charset = "utf8mb4"
 	c.Network = "mysql-tcp-12345678"
+	c.Dialer = func(context.Context, string, string) (net.Conn, error) {
+		return nil, dialerErr
+	}
 
 	dup := c.DuplicateCredentials(InstanceKey{Hostname: "otherhost", Port: 3310})
 	require.Equal(t, "otherhost", dup.Key.Hostname)
@@ -60,6 +68,8 @@ func TestDuplicateCredentials(t *testing.T) {
 	require.Equal(t, c.TransactionIsolation, dup.TransactionIsolation)
 	require.Equal(t, c.Charset, dup.Charset)
 	require.Equal(t, c.Network, dup.Network)
+	_, err := dup.Dialer(context.Background(), "tcp", "otherhost:3310")
+	require.ErrorIs(t, err, dialerErr)
 }
 
 func TestDuplicate(t *testing.T) {
@@ -82,6 +92,12 @@ func TestDuplicate(t *testing.T) {
 	require.Equal(t, transactionIsolation, dup.TransactionIsolation)
 	require.Equal(t, "utf8mb4", dup.Charset)
 	require.Equal(t, c.Network, dup.Network)
+}
+
+func TestNewConnectionConfigHasNoCustomDialer(t *testing.T) {
+	c := NewConnectionConfig()
+	var dialer gomysqlclient.Dialer = c.Dialer
+	require.Nil(t, dialer)
 }
 
 func TestGetDBUri(t *testing.T) {

--- a/go/mysql/connection_test.go
+++ b/go/mysql/connection_test.go
@@ -44,6 +44,7 @@ func TestDuplicateCredentials(t *testing.T) {
 	}
 	c.TransactionIsolation = transactionIsolation
 	c.Charset = "utf8mb4"
+	c.Network = "mysql-tcp-12345678"
 
 	dup := c.DuplicateCredentials(InstanceKey{Hostname: "otherhost", Port: 3310})
 	require.Equal(t, "otherhost", dup.Key.Hostname)
@@ -58,6 +59,7 @@ func TestDuplicateCredentials(t *testing.T) {
 	require.Equal(t, c.tlsConfig.InsecureSkipVerify, dup.tlsConfig.InsecureSkipVerify)
 	require.Equal(t, c.TransactionIsolation, dup.TransactionIsolation)
 	require.Equal(t, c.Charset, dup.Charset)
+	require.Equal(t, c.Network, dup.Network)
 }
 
 func TestDuplicate(t *testing.T) {
@@ -67,6 +69,7 @@ func TestDuplicate(t *testing.T) {
 	c.Password = "penguin"
 	c.TransactionIsolation = transactionIsolation
 	c.Charset = "utf8mb4"
+	c.Network = "mysql-tcp-12345678"
 
 	dup := c.Duplicate()
 	require.Equal(t, "myhost", dup.Key.Hostname)
@@ -78,6 +81,7 @@ func TestDuplicate(t *testing.T) {
 	require.Equal(t, c.tlsConfig, dup.tlsConfig)
 	require.Equal(t, transactionIsolation, dup.TransactionIsolation)
 	require.Equal(t, "utf8mb4", dup.Charset)
+	require.Equal(t, c.Network, dup.Network)
 }
 
 func TestGetDBUri(t *testing.T) {
@@ -108,6 +112,19 @@ func TestGetDBUriWithTLSSetup(t *testing.T) {
 
 	uri := c.GetDBUri("test")
 	require.Equal(t, `gromit:penguin@tcp(myhost:3306)/test?autocommit=true&interpolateParams=true&charset=utf8mb4_general_ci,utf8_general_ci,latin1&tls=uuidv4-myhost&timeout=1.234500s&readTimeout=1.234500s&writeTimeout=1.234500s`, uri)
+}
+
+func TestGetDBUriWithCustomNetwork(t *testing.T) {
+	c := NewConnectionConfig()
+	c.Key = InstanceKey{Hostname: "myhost", Port: 3306}
+	c.User = "gromit"
+	c.Password = "penguin"
+	c.Timeout = 1.2345
+	c.Charset = "utf8mb4,utf8,latin1"
+	c.Network = "mysql-tcp-12345678"
+
+	uri := c.GetDBUri("test")
+	require.Equal(t, `gromit:penguin@mysql-tcp-12345678(myhost:3306)/test?autocommit=true&interpolateParams=true&charset=utf8mb4,utf8,latin1&tls=false&timeout=1.234500s&readTimeout=1.234500s&writeTimeout=1.234500s`, uri)
 }
 
 func TestGetDBTLSConfigKey(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add optional custom connection hooks to `mysql.ConnectionConfig` so embedded callers can route gh-ost through a caller-managed SSH tunnel.
- Support `Network` for `go-sql-driver/mysql` DSNs instead of always generating `@tcp(host:port)`.
- Support `Dialer` for `go-mysql-org/go-mysql` binlog streamer connections, which do not use `database/sql` DSNs.
- Preserve both custom hooks when duplicating connection configs, so inspector, applier, streamer, and replica/throttle connections continue to use the same dial path.
- Add unit coverage for custom-network DSN generation and duplication behavior.

## Usage

Callers that need to route gh-ost connections through an SSH tunnel can register a custom dialer with `go-sql-driver/mysql`, then assign the registered network name and a go-mysql dialer to the gh-ost connection config:

```go
network := "mysql-tcp-" + uuid.NewString()[:8]
mysql.RegisterDialContext(network, func(ctx context.Context, addr string) (net.Conn, error) {
    return sshClient.Dial("tcp", addr)
})
defer mysql.DeregisterDialContext(network)

dbConfig := migrationContext.InspectorConnectionConfig
dbConfig.Network = network
dbConfig.Dialer = func(ctx context.Context, network, addr string) (net.Conn, error) {
    return sshClient.Dial(network, addr)
}
```

After this, gh-ost SQL connections build DSNs like:

```text
user:password@mysql-tcp-12345678(db.internal:3306)/dbname?...
```

This follows the extension model provided by `go-sql-driver/mysql`: callers register a custom network via `RegisterDialContext`, then use that network in the DSN as `network(address)`. gh-ost2 also needs the explicit `Dialer` because binlog streaming uses `go-mysql-org/go-mysql`, not `database/sql`.

With this approach, gh-ost2 remains responsible for connection configuration, while the embedding application owns SSH authentication, secret handling, host-key policy, lifecycle, and cleanup.

## Test Plan

- `go test ./go/mysql ./go/binlog ./go/base`
- `git diff --check`

Note: I also tried `go test ./go/...`, but the full suite did not exit in this local environment, so this PR validates the changed packages plus adjacent pure unit packages.
